### PR TITLE
Fix missing null byte for progname

### DIFF
--- a/core/lightsd.c
+++ b/core/lightsd.c
@@ -161,7 +161,10 @@ int
 main(int argc, char *argv[], char *envp[])
 {
     char progname[32];
-    memcpy(progname, argv[0], LGTD_MIN(sizeof(progname), strlen(argv[0])));
+
+    size_t progname_len = LGTD_MIN(sizeof(progname) - 1, strlen(argv[0]));
+    memcpy(progname, argv[0], progname_len);
+    progname[progname_len] = '\0';
 
     lgtd_daemon_setup_proctitle(argc, argv, envp);
 


### PR DESCRIPTION
progname is not static and hence is not wiped, which would be an other way to set the null byte